### PR TITLE
removed check for LogStash::Event and code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.7
+  - Code cleanup. See https://github.com/logstash-plugins/logstash-codec-s3plain/pull/2
+
 ## 2.0.6
   - Fix some documentation issues
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,6 +3,7 @@ reports, or in general have helped logstash along its way.
 
 Contributors:
 * Pier-Hugues Pellerin (ph)
+* Colin Surprenant (colinsurprenant)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/lib/logstash/codecs/s3_plain.rb
+++ b/lib/logstash/codecs/s3_plain.rb
@@ -7,24 +7,21 @@ require "logstash/util/charset"
 class LogStash::Codecs::S3Plain < LogStash::Codecs::Base
   config_name "s3_plain"
 
-  public
+  SOURCE_FIELD = "source".freeze
+  TAGS_FIELD = "tags".freeze
+  MESSAGE_FIELD = "message".freeze
+
   def decode(data)
     raise RuntimeError.new("This codec is only used for backward compatibility with the previous S3 output.")
-  end # def decode
+  end
 
-  public
   def encode(event)
-    if event.is_a?(LogStash::Event)
+    message = "Date: #{event[LogStash::Event::TIMESTAMP]}\n"
+    message << "Source: #{event[SOURCE_FIELD]}\n"
+    message << "Tags: #{Array(event[TAGS_FIELD]).join(', ')}\n"
+    message << "Fields: #{event.to_hash.inspect}\n"
+    message << "Message: #{event[MESSAGE_FIELD]}"
 
-      message = "Date: #{event[LogStash::Event::TIMESTAMP]}\n"
-      message << "Source: #{event["source"]}\n"
-      message << "Tags: #{Array(event["tags"]).join(', ')}\n"
-      message << "Fields: #{event.to_hash.inspect}\n"
-      message << "Message: #{event["message"]}"
-
-      @on_event.call(message)
-    else
-      @on_event.call(event.to_s)
-    end
-  end # def encode
-end # class LogStash::Codecs::S3Plain
+    @on_event.call(message)
+  end
+end

--- a/lib/logstash/codecs/s3_plain.rb
+++ b/lib/logstash/codecs/s3_plain.rb
@@ -16,11 +16,11 @@ class LogStash::Codecs::S3Plain < LogStash::Codecs::Base
   end
 
   def encode(event)
-    message = "Date: #{event[LogStash::Event::TIMESTAMP]}\n"
-    message << "Source: #{event[SOURCE_FIELD]}\n"
-    message << "Tags: #{Array(event[TAGS_FIELD]).join(', ')}\n"
+    message = "Date: #{event.get(LogStash::Event::TIMESTAMP)}\n"
+    message << "Source: #{event.get(SOURCE_FIELD)}\n"
+    message << "Tags: #{Array(event.get(TAGS_FIELD)).join(', ')}\n"
     message << "Fields: #{event.to_hash.inspect}\n"
-    message << "Message: #{event[MESSAGE_FIELD]}"
+    message << "Message: #{event.get(MESSAGE_FIELD)}"
 
     @on_event.call(message)
   end

--- a/logstash-codec-s3plain.gemspec
+++ b/logstash-codec-s3plain.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-s3plain'
-  s.version         = '2.0.6'
+  s.version         = '2.0.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This codec may be used to encode (via outputs) S3plain text format, this make the S3 outputs backward compatible with Logstash 1.4.2"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-codec-s3plain.gemspec
+++ b/logstash-codec-s3plain.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "codec" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-devutils'
 end
 

--- a/spec/codecs/s3_plain_spec.rb
+++ b/spec/codecs/s3_plain_spec.rb
@@ -9,7 +9,7 @@ describe LogStash::Codecs::S3Plain do
   describe "#encode" do
     it 'should accept a nil list for the tags' do
       subject.on_event do |data|
-        data.should match(/\nTags:\s\n/)
+        expect(data).to match(/\nTags:\s\n/)
       end
 
       subject.encode(LogStash::Event.new)
@@ -19,7 +19,7 @@ describe LogStash::Codecs::S3Plain do
       event = LogStash::Event.new({"tags" => ["elasticsearch", "logstash", "kibana"] })
 
       subject.on_event do |data|
-        data.should match(/\nTags:\selasticsearch,\slogstash,\skibana\n/)
+        expect(data).to match(/\nTags:\selasticsearch,\slogstash,\skibana\n/)
       end
 
       subject.encode(event)

--- a/spec/codecs/s3_plain_spec.rb
+++ b/spec/codecs/s3_plain_spec.rb
@@ -24,15 +24,5 @@ describe LogStash::Codecs::S3Plain do
 
       subject.encode(event)
     end
-
-    it "return to_s if its not LogStash::Event" do
-      event = {"test" => "A-B-C" }
-
-      subject.on_event do |data|
-        data.should == event.to_s
-      end
-
-      subject.encode(event)
-    end
-  end
+   end
 end


### PR DESCRIPTION
Per elastic/logstash/issues/8847 removed check for `LogStash::Event` and code cleanup.
